### PR TITLE
Ordonnance n॰ 2017-1387 du 22 septembre 2017 - Article 21

### DIFF
--- a/01. Partie législative  /Article L1222-10 - 25558062.md
+++ b/01. Partie législative  /Article L1222-10 - 25558062.md
@@ -2,19 +2,14 @@
 
 Outre ses obligations de droit commun vis-à-vis de ses salariés, l'employeur est tenu à l'égard du salarié en télétravail : 
 
-1° De prendre en charge tous les coûts découlant directement de l'exercice du télétravail, notamment le coût des matériels,
-logiciels, abonnements, communications et outils ainsi que de la maintenance de ceux-ci ; 
-
-2° D'informer le salarié de toute restriction à l'usage d'équipements ou outils informatiques ou de services de communication
+1° D'informer le salarié de toute restriction à l'usage d'équipements ou outils informatiques ou de services de communication
 électronique et des sanctions en cas de non-respect de telles restrictions ; 
 
-3° De lui donner priorité pour occuper ou reprendre un poste sans télétravail qui correspond à ses qualifications et
+2° De lui donner priorité pour occuper ou reprendre un poste sans télétravail qui correspond à ses qualifications et
 compétences professionnelles et de porter à sa connaissance la disponibilité de tout poste de cette nature ; 
 
-4° D'organiser chaque année un entretien qui porte notamment sur les conditions d'activité du salarié et sa charge de
-travail ; 
-
-5° De fixer, en concertation avec lui, les plages horaires durant lesquelles il peut habituellement le contacter.
+3° D'organiser chaque année un entretien qui porte notamment sur les conditions d'activité du salarié et sa charge de
+travail. 
 
 **Liens relatifs à cet article**
 

--- a/01. Partie législative  /Article L1222-11 - 25558064.md
+++ b/01. Partie législative  /Article L1222-11 - 25558064.md
@@ -2,8 +2,7 @@
 
 En cas de circonstances exceptionnelles, notamment de menace d'épidémie, ou en cas de force majeure, la mise en œuvre du
 télétravail peut être considérée comme un aménagement du poste de travail rendu nécessaire pour permettre la continuité de
-l'activité de l'entreprise et garantir la protection des salariés. Les conditions et les modalités d'application du présent
-article sont définies par décret en Conseil d'Etat.
+l'activité de l'entreprise et garantir la protection des salariés. 
 
 **Liens relatifs à cet article**
 

--- a/01. Partie législative  /Article L1222-9 - 25558060.md
+++ b/01. Partie législative  /Article L1222-9 - 25558060.md
@@ -2,19 +2,29 @@
 
 Sans préjudice de l'application, s'il y a lieu, des dispositions du présent code protégeant les travailleurs à domicile, le
 télétravail désigne toute forme d'organisation du travail dans laquelle un travail qui aurait également pu être exécuté dans
-les locaux de l'employeur est effectué par un salarié hors de ces locaux de façon régulière et volontaire en utilisant les
-technologies de l'information et de la communication dans le cadre d'un contrat de travail ou d'un avenant à celui-ci.
+les locaux de l'employeur est effectué par un salarié hors de ces locaux de façon volontaire en utilisant les
+technologies de l'information et de la communication.
 
-Le télétravailleur désigne toute personne salariée de l'entreprise qui effectue, soit dès l'embauche, soit ultérieurement, du
-télétravail tel que défini au premier alinéa. 
+Le télétravail est mis en place dans le cadre d'un accord collectif ou, à défaut, dans le cadre d'une charte élaborée par l'employeur après avis du comité social économique, s'il existe.
+
+En l'absence de charte ou d'accord collectif, lorsque le salarié et l'employeur conviennent de recourir de manière occasionnelle au télétravail, ils formalisent leur accord par tout moyen. 
+
+Est qualifié de télétravailleur au sens de la présente section tout salarié de l'entreprise qui effectue, soit dès l'embauche, soit ultérieurement, du télétravail tel que défini au premier alinéa.
+
+Le télétravailleur a les mêmes droits que le salarié qui exécute son travail dans les locaux de l'entreprise, notamment en ce qui concerne l'accès aux informations syndicales, la participation aux élections professionnelles et l'accès à la formation.
+
+L'employeur qui refuse d'accorder le bénéfice du télétravail à un salarié qui occupe un poste éligible à un mode d'organisation en télétravail dans les conditions prévues par accord collectif ou, à défaut, par la charte, doit motiver sa réponse. 
 
 Le refus d'accepter un poste de télétravailleur n'est pas un motif de rupture du contrat de travail. 
 
-Le contrat de travail ou son avenant précise les conditions de passage en télétravail et les conditions de retour à une
-exécution du contrat de travail sans télétravail. 
+L'accord collectif applicable ou, à défaut, la charte élaborée par l'employeur précise :
 
-A défaut d'accord collectif applicable, le contrat de travail ou son avenant précise les modalités de contrôle du temps de
-travail.
+1. Les conditions de passage en télétravail et les conditions de retour à une exécution du contrat de travail sans télétravail ;
+2. Les modalités d'acceptation par le salarié des conditions de mise en œuvre du télétravail ;
+3. Les modalités de contrôle du temps de travail ou de régulation de la charge de travail ;
+4. La détermination des plages horaires durant lesquelles l'employeur peut habituellement contacter le salarié en télétravail.
+
+L'accident survenu sur le lieu où est exercé le télétravail pendant l'exercice de l'activité professionnelle du télétravailleur est présumé être un accident de travail au sens des dispositions de l'article L. 411-1 du code de la sécurité sociale. 
 
 **Liens relatifs à cet article**
 


### PR DESCRIPTION
D'après [l'ordonnance sur Légifrance](https://www.legifrance.gouv.fr/affichTexte.do?cidTexte=JORFTEXT000035607388&idJO=JORFCONT000035606911), voici les modifications apportées aux articles de loi concernant le télétravail: 

> # Titre III : MODIFICATIONS DES RÈGLES DE RECOURS À CERTAINES FORMES PARTICULIÈRES DE TRAVAIL
> 
> ## Chapitre Ier : Favoriser le recours au télétravail
> ### Article 21
> 
> 
> La section 4 du chapitre II du titre II du livre II de la première partie du même code intitulée « Télétravail » est ainsi modifiée :
> 1° L'article L. 1222-9 est ainsi modifié :
> a) Au premier alinéa de l'article L. 1222-9, après les mots : « de façon », les mots : « régulière et » sont supprimés et après les mots : « la communication », les mots : « dans le cadre d'un contrat de travail ou d'un avenant à celui-ci » sont supprimés ;
> b) Après le premier alinéa, sont ajoutés deux alinéas ainsi rédigés :
> « Le télétravail est mis en place dans le cadre d'un accord collectif ou, à défaut, dans le cadre d'une charte élaborée par l'employeur après avis du comité social économique, s'il existe.
> « En l'absence de charte ou d'accord collectif, lorsque le salarié et l'employeur conviennent de recourir de manière occasionnelle au télétravail, ils formalisent leur accord par tout moyen. » ;
> c) Au deuxième alinéa, les mots : « Le télétravailleur désigne toute personne salariée » sont remplacés par les mots : « Est qualifié de télétravailleur au sens de la présente section tout salarié » ;
> d) Après le deuxième alinéa, sont ajoutés deux alinéas ainsi rédigés :
> « Le télétravailleur a les mêmes droits que le salarié qui exécute son travail dans les locaux de l'entreprise, notamment en ce qui concerne l'accès aux informations syndicales, la participation aux élections professionnelles et l'accès à la formation.
> « L'employeur qui refuse d'accorder le bénéfice du télétravail à un salarié qui occupe un poste éligible à un mode d'organisation en télétravail dans les conditions prévues par accord collectif ou, à défaut, par la charte, doit motiver sa réponse. » ;
> e) Les deux derniers alinéas sont remplacés par les six alinéas ainsi rédigés :
> « L'accord collectif applicable ou, à défaut, la charte élaborée par l'employeur précise :
> « 1° Les conditions de passage en télétravail et les conditions de retour à une exécution du contrat de travail sans télétravail ;
> « 2° Les modalités d'acceptation par le salarié des conditions de mise en œuvre du télétravail ;
> « 3° Les modalités de contrôle du temps de travail ou de régulation de la charge de travail ;
> « 4° La détermination des plages horaires durant lesquelles l'employeur peut habituellement contacter le salarié en télétravail.
> « L'accident survenu sur le lieu où est exercé le télétravail pendant l'exercice de l'activité professionnelle du télétravailleur est présumé être un accident de travail au sens des dispositions de l'article L. 411-1 du code de la sécurité sociale. » ;
> 2° L'article L. 1222-10 est ainsi modifié :
> a) Le deuxième alinéa est supprimé ;
> b) Au troisième alinéa, la numérotation : « 2° » est remplacée par la numérotation : « 1° » ;
> c) Au quatrième alinéa, la numérotation : « 3° » est remplacée par la numérotation : « 2° » ;
> d) Au cinquième alinéa, la numérotation : « 4° » est remplacée par la numérotation : « 3° » ;
> e) Au même alinéa, les mots : « sa charge de travail ; » sont remplacés par les mots : « sa charge de travail. » ;
> f) Le dernier alinéa est supprimé ;
> 3° La dernière phrase de l'article L. 1222-11 est supprimée.